### PR TITLE
Changed invalid email messaging, removed workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ capybara-*.html
 **.orig
 rerun.txt
 pickle-email-*.html
+*~
 
 # TODO Comment out these rules if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb

--- a/email-validation.gemspec
+++ b/email-validation.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'activerecord','>= 3.0'
   s.add_dependency 'protected_attributes'
   s.add_dependency 'stoplight', '~> 1.0'
-  s.add_dependency 'workflow'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'shoulda-matchers'
   s.add_development_dependency 'rspec'

--- a/lib/email-validation.rb
+++ b/lib/email-validation.rb
@@ -3,13 +3,8 @@ require 'email-validation/blacklisted_email'
 require 'email-validation/config'
 
 module EmailValidation
-  def self.invalid_email_message
-    "Your email address is invalid. Please #{self.contact_link} if you need further assistance."
-  end
-
-  def self.not_verified_email_message
-    "Your email address could not be verified. Please #{self.contact_link} if you need further assistance."
-  end
+  INVALID_EMAIL_MESSAGE = "Your email address is invalid. Please <a href='/contact' title='Customer Service'>contact customer service</a> if you need further assistance."
+  NOT_VERIFIED_EMAIL_MESSAGE = "Your email address could not be verified. Please <a href='/contact' title='Customer Service'>contact customer service</a> if you need further assistance."
 
   class << self
     attr_writer :config
@@ -21,9 +16,5 @@ module EmailValidation
 
   def self.configure
     yield(config)
-  end
-
-  def self.contact_link
-    "<a href='/contact' title='Customer Service'>contact customer service</a>"
   end
 end

--- a/lib/email-validation.rb
+++ b/lib/email-validation.rb
@@ -3,9 +3,6 @@ require 'email-validation/blacklisted_email'
 require 'email-validation/config'
 
 module EmailValidation
-  INVALID_EMAIL_MESSAGE = "Your email address is invalid. Please <a href='/contact' title='Customer Service'>contact customer service</a> if you need further assistance."
-  NOT_VERIFIED_EMAIL_MESSAGE = "Your email address could not be verified. Please <a href='/contact' title='Customer Service'>contact customer service</a> if you need further assistance."
-
   class << self
     attr_writer :config
   end

--- a/lib/email-validation.rb
+++ b/lib/email-validation.rb
@@ -3,8 +3,12 @@ require 'email-validation/blacklisted_email'
 require 'email-validation/config'
 
 module EmailValidation
-  def self.incorrect_email_message(email)
-    "The email address you have entered (#{email}) is incorrect."
+  def self.invalid_email_message
+    "Your email address is invalid. Please #{self.contact_link} if you need further assistance."
+  end
+
+  def self.could_not_verified_email_message
+    "Your email address could not be verified. Please #{self.contact_link} if you need further assistance."
   end
 
   class << self
@@ -17,5 +21,9 @@ module EmailValidation
 
   def self.configure
     yield(config)
+  end
+
+  def self.contact_link
+    "<a href='/contact' title='Customer Service'>contact customer service</a>"
   end
 end

--- a/lib/email-validation.rb
+++ b/lib/email-validation.rb
@@ -7,7 +7,7 @@ module EmailValidation
     "Your email address is invalid. Please #{self.contact_link} if you need further assistance."
   end
 
-  def self.could_not_verified_email_message
+  def self.not_verified_email_message
     "Your email address could not be verified. Please #{self.contact_link} if you need further assistance."
   end
 

--- a/lib/email-validation/blacklisted_email.rb
+++ b/lib/email-validation/blacklisted_email.rb
@@ -23,14 +23,13 @@ module EmailValidation
       state :admin
     end
 
-    ORIGIN_KICKBOX = 'kickbox'
     ORIGIN_ADMIN = 'admin'
     ORIGIN_BOUNCE = 'bounce'
     ORIGIN_UNSUBSCRIBE = 'unsubscribe'
 
-    def self.exists? email
+    def self.exists_as_bounce_or_admin? email
       email = BlacklistedEmail.parse_email_address(email.to_s)
-      BlacklistedEmail.where(email: email).exists?
+      BlacklistedEmail.where(email: email, origin: [ORIGIN_BOUNCE, ORIGIN_ADMIN]).exists?
     end
 
     def self.bounced? email

--- a/lib/email-validation/blacklisted_email.rb
+++ b/lib/email-validation/blacklisted_email.rb
@@ -5,7 +5,6 @@ require 'workflow'
 module EmailValidation
   class BlacklistedEmail < ::ActiveRecord::Base
     self.table_name = 'blacklisted_emails'
-    scope :bounce_or_admin, -> { where(origin: [ORIGIN_BOUNCE, ORIGIN_ADMIN]) }
 
     include Workflow
     workflow_column :origin
@@ -27,7 +26,7 @@ module EmailValidation
     ORIGIN_BOUNCE = 'bounce'
     ORIGIN_UNSUBSCRIBE = 'unsubscribe'
 
-    def self.exists_as_bounce_or_admin? email
+    def self.bounce_or_admin? email
       email = BlacklistedEmail.parse_email_address(email.to_s)
       BlacklistedEmail.where(email: email, origin: [ORIGIN_BOUNCE, ORIGIN_ADMIN]).exists?
     end

--- a/lib/email-validation/blacklisted_email.rb
+++ b/lib/email-validation/blacklisted_email.rb
@@ -5,6 +5,7 @@ require 'workflow'
 module EmailValidation
   class BlacklistedEmail < ::ActiveRecord::Base
     self.table_name = 'blacklisted_emails'
+    scope :bounce_or_admin, -> { where(origin: [ORIGIN_BOUNCE, ORIGIN_ADMIN]) }
 
     include Workflow
     workflow_column :origin

--- a/lib/email-validation/blacklisted_email.rb
+++ b/lib/email-validation/blacklisted_email.rb
@@ -23,6 +23,7 @@ module EmailValidation
       state :admin
     end
 
+    ORIGIN_KICKBOX = 'kickbox'
     ORIGIN_ADMIN = 'admin'
     ORIGIN_BOUNCE = 'bounce'
     ORIGIN_UNSUBSCRIBE = 'unsubscribe'

--- a/lib/email-validation/blacklisted_email.rb
+++ b/lib/email-validation/blacklisted_email.rb
@@ -1,13 +1,9 @@
 require 'active_record'
 require 'protected_attributes'
-require 'workflow'
 
 module EmailValidation
   class BlacklistedEmail < ::ActiveRecord::Base
     self.table_name = 'blacklisted_emails'
-
-    include Workflow
-    workflow_column :origin
 
     attr_accessible :email, :origin
 
@@ -15,12 +11,6 @@ module EmailValidation
     validates :email, presence: true, uniqueness: true, format: { with: /\A[^\s]+@[^\s]+\z/i }
 
     before_save :parse_email
-
-    workflow do
-      state :bounce
-      state :unsubscribe
-      state :admin
-    end
 
     ORIGIN_ADMIN = 'admin'
     ORIGIN_BOUNCE = 'bounce'

--- a/lib/email-validation/config.rb
+++ b/lib/email-validation/config.rb
@@ -4,7 +4,7 @@ module EmailValidation
     attr_accessor :timeout
     attr_accessor :after_error_hook
     attr_accessor :kickbox_api_key
-    attr_accessor :baunced_or_blacklisted_email_message
+    attr_accessor :bounced_or_blacklisted_email_message
     attr_accessor :not_verified_email_message
 
     DEFAULT_TIMEOUT = 60
@@ -14,7 +14,7 @@ module EmailValidation
       @stoplight_threshold = 10
       @timeout = 60
       @after_error_hook = ->(e) {}
-      @baunced_or_blacklisted_email_message = "Your email address is blocked due to undeliverable emails. Please <small><a href='/contact' title='Customer Service'>contact customer service</a></small> if you need further assistance."
+      @bounced_or_blacklisted_email_message = "Your email address is blocked due to undeliverable emails. Please <small><a href='/contact' title='Customer Service'>contact customer service</a></small> if you need further assistance."
       @not_verified_email_message = "Your email address could not be verified. Please <small><a href='/contact' title='Customer Service'>contact customer service</a></small> if you need further assistance."
     end
   end

--- a/lib/email-validation/config.rb
+++ b/lib/email-validation/config.rb
@@ -4,7 +4,7 @@ module EmailValidation
     attr_accessor :timeout
     attr_accessor :after_error_hook
     attr_accessor :kickbox_api_key
-    attr_accessor :invalid_email_message
+    attr_accessor :baunced_or_blacklisted_email_message
     attr_accessor :not_verified_email_message
 
     DEFAULT_TIMEOUT = 60
@@ -14,7 +14,7 @@ module EmailValidation
       @stoplight_threshold = 10
       @timeout = 60
       @after_error_hook = ->(e) {}
-      @invalid_email_message = "Your email address is invalid. Please <small><a href='/contact' title='Customer Service'>contact customer service</a></small> if you need further assistance."
+      @baunced_or_blacklisted_email_message = "Your email address is invalid. Please <small><a href='/contact' title='Customer Service'>contact customer service</a></small> if you need further assistance."
       @not_verified_email_message = "Your email address could not be verified. Please <small><a href='/contact' title='Customer Service'>contact customer service</a></small> if you need further assistance."
     end
   end

--- a/lib/email-validation/config.rb
+++ b/lib/email-validation/config.rb
@@ -4,17 +4,18 @@ module EmailValidation
     attr_accessor :timeout
     attr_accessor :after_error_hook
     attr_accessor :kickbox_api_key
+    attr_accessor :invalid_email_message
+    attr_accessor :not_verified_email_message
 
     DEFAULT_TIMEOUT = 60
     DEFAULT_THRESHOLD = 10
-    
-    INVALID_EMAIL_MESSAGE = "Your email address is invalid. Please <a href='/contact' title='Customer Service'>contact customer service</a> if you need further assistance."
-    NOT_VERIFIED_EMAIL_MESSAGE = "Your email address could not be verified. Please <a href='/contact' title='Customer Service'>contact customer service</a> if you need further assistance."
 
     def initialize
       @stoplight_threshold = 10
       @timeout = 60
       @after_error_hook = ->(e) {}
+      @invalid_email_message = "Your email address is invalid. Please <small><a href='/contact' title='Customer Service'>contact customer service</a></small> if you need further assistance."
+      @not_verified_email_message = "Your email address could not be verified. Please <small><a href='/contact' title='Customer Service'>contact customer service</a></small> if you need further assistance."
     end
   end
 end

--- a/lib/email-validation/config.rb
+++ b/lib/email-validation/config.rb
@@ -7,6 +7,9 @@ module EmailValidation
 
     DEFAULT_TIMEOUT = 60
     DEFAULT_THRESHOLD = 10
+    
+    INVALID_EMAIL_MESSAGE = "Your email address is invalid. Please <a href='/contact' title='Customer Service'>contact customer service</a> if you need further assistance."
+    NOT_VERIFIED_EMAIL_MESSAGE = "Your email address could not be verified. Please <a href='/contact' title='Customer Service'>contact customer service</a> if you need further assistance."
 
     def initialize
       @stoplight_threshold = 10

--- a/lib/email-validation/config.rb
+++ b/lib/email-validation/config.rb
@@ -14,7 +14,7 @@ module EmailValidation
       @stoplight_threshold = 10
       @timeout = 60
       @after_error_hook = ->(e) {}
-      @baunced_or_blacklisted_email_message = "Your email address is invalid. Please <small><a href='/contact' title='Customer Service'>contact customer service</a></small> if you need further assistance."
+      @baunced_or_blacklisted_email_message = "Your email address is blocked due to undeliverable emails. Please <small><a href='/contact' title='Customer Service'>contact customer service</a></small> if you need further assistance."
       @not_verified_email_message = "Your email address could not be verified. Please <small><a href='/contact' title='Customer Service'>contact customer service</a></small> if you need further assistance."
     end
   end

--- a/lib/email-validation/strategy.rb
+++ b/lib/email-validation/strategy.rb
@@ -4,7 +4,7 @@ module EmailValidation
   class Strategy
 
     def verify_email(email)
-      return false, EmailValidation.config.invalid_email_message if BlacklistedEmail.bounce_or_admin?(email)
+      return false, EmailValidation.config.baunced_or_blacklisted_email_message if BlacklistedEmail.bounce_or_admin?(email)
 
       validation_result, msg = ValidationResult.new(true, true), ''
 

--- a/lib/email-validation/strategy.rb
+++ b/lib/email-validation/strategy.rb
@@ -4,7 +4,7 @@ module EmailValidation
   class Strategy
 
     def verify_email(email)
-      return false, EmailValidation::INVALID_EMAIL_MESSAGE if BlacklistedEmail.bounce_or_admin?(email)
+      return false, EmailValidation::Config::INVALID_EMAIL_MESSAGE if BlacklistedEmail.bounce_or_admin?(email)
 
       validation_result, msg = ValidationResult.new(true, true), ''
 
@@ -19,7 +19,7 @@ module EmailValidation
 
       unless validation_result.valid?
         BlacklistedEmail.create(email: email, origin: validation_result.reason)
-        msg = EmailValidation::NOT_VERIFIED_EMAIL_MESSAGE
+        msg = EmailValidation::Config::NOT_VERIFIED_EMAIL_MESSAGE
       end
 
       return [validation_result.valid?, msg]

--- a/lib/email-validation/strategy.rb
+++ b/lib/email-validation/strategy.rb
@@ -19,7 +19,7 @@ module EmailValidation
 
       unless validation_result.valid?
         BlacklistedEmail.create(email: email, origin: validation_result.reason)
-        msg = EmailValidation::could_not_verified_email_message
+        msg = EmailValidation::not_verified_email_message
       end
 
       return [validation_result.valid?, msg]

--- a/lib/email-validation/strategy.rb
+++ b/lib/email-validation/strategy.rb
@@ -4,7 +4,7 @@ module EmailValidation
   class Strategy
 
     def verify_email(email)
-      return false, EmailValidation.config.baunced_or_blacklisted_email_message if BlacklistedEmail.bounce_or_admin?(email)
+      return false, EmailValidation.config.bounced_or_blacklisted_email_message if BlacklistedEmail.bounce_or_admin?(email)
 
       validation_result, msg = ValidationResult.new(true, true), ''
 

--- a/lib/email-validation/strategy.rb
+++ b/lib/email-validation/strategy.rb
@@ -17,7 +17,7 @@ module EmailValidation
         end
       end
 
-      unless validation_result.valid?
+      if !validation_result.valid?
         BlacklistedEmail.create(email: email, origin: validation_result.reason)
         msg = EmailValidation::Config::NOT_VERIFIED_EMAIL_MESSAGE
       end

--- a/lib/email-validation/strategy.rb
+++ b/lib/email-validation/strategy.rb
@@ -4,7 +4,7 @@ module EmailValidation
   class Strategy
 
     def verify_email(email)
-      return false, EmailValidation::incorrect_email_message(email) if BlacklistedEmail.exists?(email)
+      return false, EmailValidation::invalid_email_message if BlacklistedEmail.bounce_or_admin.exists?(email)
 
       validation_result = nil
 

--- a/lib/email-validation/strategy.rb
+++ b/lib/email-validation/strategy.rb
@@ -17,6 +17,7 @@ module EmailValidation
         end
       end
 
+
       validation_result ||= ValidationResult.new(true, true)
 
       BlacklistedEmail.create(email: email, origin: validation_result.reason) unless validation_result.valid?

--- a/lib/email-validation/strategy.rb
+++ b/lib/email-validation/strategy.rb
@@ -4,7 +4,7 @@ module EmailValidation
   class Strategy
 
     def verify_email(email)
-      return false, EmailValidation::invalid_email_message if BlacklistedEmail.bounce_or_admin.exists?(email)
+      return false, EmailValidation::invalid_email_message if BlacklistedEmail.exists?(email)
 
       validation_result = nil
 

--- a/lib/email-validation/strategy.rb
+++ b/lib/email-validation/strategy.rb
@@ -4,7 +4,7 @@ module EmailValidation
   class Strategy
 
     def verify_email(email)
-      return false, EmailValidation::Config::INVALID_EMAIL_MESSAGE if BlacklistedEmail.bounce_or_admin?(email)
+      return false, EmailValidation.config.invalid_email_message if BlacklistedEmail.bounce_or_admin?(email)
 
       validation_result, msg = ValidationResult.new(true, true), ''
 
@@ -19,7 +19,7 @@ module EmailValidation
 
       if !validation_result.valid?
         BlacklistedEmail.create(email: email, origin: validation_result.reason)
-        msg = EmailValidation::Config::NOT_VERIFIED_EMAIL_MESSAGE
+        msg = EmailValidation.config.not_verified_email_message
       end
 
       return [validation_result.valid?, msg]

--- a/lib/email-validation/strategy.rb
+++ b/lib/email-validation/strategy.rb
@@ -4,7 +4,7 @@ module EmailValidation
   class Strategy
 
     def verify_email(email)
-      return false, EmailValidation::invalid_email_message if BlacklistedEmail.bounce_or_admin?(email)
+      return false, EmailValidation::INVALID_EMAIL_MESSAGE if BlacklistedEmail.bounce_or_admin?(email)
 
       validation_result, msg = ValidationResult.new(true, true), ''
 
@@ -19,7 +19,7 @@ module EmailValidation
 
       unless validation_result.valid?
         BlacklistedEmail.create(email: email, origin: validation_result.reason)
-        msg = EmailValidation::not_verified_email_message
+        msg = EmailValidation::NOT_VERIFIED_EMAIL_MESSAGE
       end
 
       return [validation_result.valid?, msg]

--- a/spec/email-validation/email_validation_strategy_spec.rb
+++ b/spec/email-validation/email_validation_strategy_spec.rb
@@ -13,7 +13,7 @@ module EmailValidation
 
           status, message = subject.verify_email(email)
 
-          expect(message).to eq EmailValidation.config.invalid_email_message
+          expect(message).to eq EmailValidation.config.baunced_or_blacklisted_email_message
           expect(status).to eq false
         end
       end

--- a/spec/email-validation/email_validation_strategy_spec.rb
+++ b/spec/email-validation/email_validation_strategy_spec.rb
@@ -13,7 +13,7 @@ module EmailValidation
 
           status, message = subject.verify_email(email)
 
-          expect(message).to eq EmailValidation::Config::INVALID_EMAIL_MESSAGE
+          expect(message).to eq EmailValidation.config.invalid_email_message
           expect(status).to eq false
         end
       end

--- a/spec/email-validation/email_validation_strategy_spec.rb
+++ b/spec/email-validation/email_validation_strategy_spec.rb
@@ -6,7 +6,7 @@ module EmailValidation
       let(:email) { "test@test.com" }
 
       context "when the email is blacklisted" do
-        before { expect(BlacklistedEmail).to receive(:exists?).and_return(true) }
+        before { expect(BlacklistedEmail).to receive(:bounce_or_admin?).and_return(true) }
 
         it "checks for blacklisted emails first" do
           expect_any_instance_of(Validators::KickboxEmailValidator).not_to receive(:validate_email)
@@ -15,12 +15,11 @@ module EmailValidation
 
           expect(message).to eq EmailValidation::invalid_email_message
           expect(status).to eq false
-
         end
       end
 
       context "when the email is not blacklisted" do
-        before { expect(BlacklistedEmail).to receive(:exists?).and_return(false) }
+        before { expect(BlacklistedEmail).to receive(:bounce_or_admin?).and_return(false) }
 
         it "uses Kickbox after making sure the email is not blacklisted" do
           expect_any_instance_of(Validators::KickboxEmailValidator).to receive(:perform_validation).
@@ -76,14 +75,14 @@ module EmailValidation
       end
 
       context "blacklisting emails" do
-        before { expect(BlacklistedEmail).to receive(:exists?).and_return(false) }
+        before { expect(BlacklistedEmail).to receive(:bounce_or_admin?).and_return(false) }
 
         context "when the email is invalid" do
           it "blacklists the email" do
             expect_any_instance_of(Validators::KickboxEmailValidator).to receive(:validate_email).
                                                                           with(email).
                                                                           and_return(ValidationResult.new(false, true, 'kickbox reason'))
-            
+
             expect(BlacklistedEmail).to receive(:create).with(email: email, origin: 'kickbox reason')
 
             subject.verify_email(email)

--- a/spec/email-validation/email_validation_strategy_spec.rb
+++ b/spec/email-validation/email_validation_strategy_spec.rb
@@ -13,7 +13,7 @@ module EmailValidation
 
           status, message = subject.verify_email(email)
 
-          expect(message).to eq EmailValidation::INVALID_EMAIL_MESSAGE
+          expect(message).to eq EmailValidation::Config::INVALID_EMAIL_MESSAGE
           expect(status).to eq false
         end
       end

--- a/spec/email-validation/email_validation_strategy_spec.rb
+++ b/spec/email-validation/email_validation_strategy_spec.rb
@@ -13,7 +13,7 @@ module EmailValidation
 
           status, message = subject.verify_email(email)
 
-          expect(message).to eq EmailValidation::incorrect_email_message(email)
+          expect(message).to eq EmailValidation::invalid_email_message
           expect(status).to eq false
 
         end

--- a/spec/email-validation/email_validation_strategy_spec.rb
+++ b/spec/email-validation/email_validation_strategy_spec.rb
@@ -13,7 +13,7 @@ module EmailValidation
 
           status, message = subject.verify_email(email)
 
-          expect(message).to eq EmailValidation::invalid_email_message
+          expect(message).to eq EmailValidation::INVALID_EMAIL_MESSAGE
           expect(status).to eq false
         end
       end

--- a/spec/email-validation/email_validation_strategy_spec.rb
+++ b/spec/email-validation/email_validation_strategy_spec.rb
@@ -13,7 +13,7 @@ module EmailValidation
 
           status, message = subject.verify_email(email)
 
-          expect(message).to eq EmailValidation.config.baunced_or_blacklisted_email_message
+          expect(message).to eq EmailValidation.config.bounced_or_blacklisted_email_message
           expect(status).to eq false
         end
       end

--- a/spec/email-validation_spec.rb
+++ b/spec/email-validation_spec.rb
@@ -28,7 +28,7 @@ describe EmailValidation do
     it { expect(EmailValidation.invalid_email_message).to match('email address is invalid') }
   end
 
-  describe "self.could_not_verified_email_message" do
+  describe "self.not_verified_email_message" do
     it { expect(EmailValidation.could_not_verified_email_message).to match('address could not be verified') }
   end
 

--- a/spec/email-validation_spec.rb
+++ b/spec/email-validation_spec.rb
@@ -24,16 +24,4 @@ describe EmailValidation do
     end
   end
 
-  describe "self.invalid_email_message" do
-    it { expect(EmailValidation.invalid_email_message).to match('email address is invalid') }
-  end
-
-  describe "self.not_verified_email_message" do
-    it { expect(EmailValidation.could_not_verified_email_message).to match('address could not be verified') }
-  end
-
-  describe "self.contact_link" do
-    it { expect(EmailValidation.contact_link).to match("href='/contact'") }
-  end
-
 end

--- a/spec/email-validation_spec.rb
+++ b/spec/email-validation_spec.rb
@@ -23,4 +23,17 @@ describe EmailValidation do
       expect(EmailValidation.config.kickbox_api_key).to eq 'key-123-456'
     end
   end
+
+  describe "self.invalid_email_message" do
+    it { expect(EmailValidation.invalid_email_message).to match('email address is invalid') }
+  end
+
+  describe "self.could_not_verified_email_message" do
+    it { expect(EmailValidation.could_not_verified_email_message).to match('address could not be verified') }
+  end
+
+  describe "self.contact_link" do
+    it { expect(EmailValidation.contact_link).to match("href='/contact'") }
+  end
+
 end


### PR DESCRIPTION
still require:
- adding redirect to 39C from /contact to /info/contact
- updating spec/controllers/newsletter_subscriptions_controller_spec.rb spec that is using workflow generated methods: "bounce?" and "unsubsribe?"
